### PR TITLE
Fix message pagination callback

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -57,7 +57,7 @@ module.exports = function(client){
 			data = stringifykv(obj);
 		}
 		var len = data.length;
-		var sendMessage = function(data, start, end){
+		var sendMessage = function(data, start, end, cb){
 			var contentLen = end - start;
 			var paddingLen = (8 - (contentLen % 8)) % 8;
 			if(start || end !== len) data = data.slice(start, end);
@@ -77,9 +77,9 @@ module.exports = function(client){
 			}
 		};
 		for(var start=0; start < len - 0xffff; start += 0xffff) {
-			sendMessage(data, start, start + 0xffff);
+			sendMessage(data, start, start + 0xffff, null);
 		}
-		sendMessage(data, start, len);
+		sendMessage(data, start, len, cb);
 	};
 
 	// receive message


### PR DESCRIPTION
With the current implementation when a message is too large (>= 0xFFFF bytes), the callback of  `send` will be invoked more than once. This can cause for example a multiple callback error:

```
Node.js v20.11.1
node:events:496
      throw er; // Unhandled 'error' event
      ^

Error [ERR_MULTIPLE_CALLBACK]: Callback called multiple times
    at onwrite (node:internal/streams/writable:611:28)
    at afterWrite (node:internal/streams/writable:701:5)
    at afterWriteTick (node:internal/streams/writable:687:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:81:21)
Emitted 'error' event on Writable instance at:
    at Writable.onerror (node:internal/streams/readable:1026:14)
    at Writable.emit (node:events:518:28)
    at emitErrorNT (node:internal/streams/destroy:169:8)
    at emitErrorCloseNT (node:internal/streams/destroy:128:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  code: 'ERR_MULTIPLE_CALLBACK'
}
```

This patch ensures only the last page of a message will be bond with a callback.